### PR TITLE
Update Skygear version to 1.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ android:
     - tools
     - tools # as per https://github.com/travis-ci/travis-ci/issues/6040#issuecomment-219367943
     - platform-tools
-    - build-tools-26.0.2
-    - android-26
+    - build-tools-27.0.3
+    - android-27
     - extra-android-support
     - extra-android-m2repository
     - extra-google-m2repository

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion getBuildToolsVersionAtLeast("26.0.2")
+    compileSdkVersion 27
+    buildToolsVersion getBuildToolsVersionAtLeast("27.0.3")
 
     defaultConfig {
         applicationId "io.skygear.skygear_starter_project"
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
@@ -22,8 +22,9 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'junit:junit:4.12'
-    implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'io.skygear:skygear:+'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:design:27.1.1'
+    implementation 'io.skygear:skygear:1.6.0'
 }
 
 /**

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,10 +20,10 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'io.skygear:skygear:+'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'io.skygear:skygear:+'
 }
 
 /**

--- a/app/src/main/java/io/skygear/skygear_starter_project/MainActivity.java
+++ b/app/src/main/java/io/skygear/skygear_starter_project/MainActivity.java
@@ -37,17 +37,17 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        this.endpointTextView = (TextView) findViewById(R.id.endpoint_text_view);
-        this.apiKeyTextView = (TextView) findViewById(R.id.api_key_text_view);
-        this.accessTokenTextView = (TextView) findViewById(R.id.access_token_text_view);
-        this.userIdTextView = (TextView) findViewById(R.id.user_id_text_view);
+        this.endpointTextView = findViewById(R.id.endpoint_text_view);
+        this.apiKeyTextView = findViewById(R.id.api_key_text_view);
+        this.accessTokenTextView = findViewById(R.id.access_token_text_view);
+        this.userIdTextView = findViewById(R.id.user_id_text_view);
 
-        this.emailEditText = (EditText) findViewById(R.id.email_edit_text);
-        this.passwordEditText = (EditText) findViewById(R.id.password_edit_text);
+        this.emailEditText = findViewById(R.id.email_edit_text);
+        this.passwordEditText = findViewById(R.id.password_edit_text);
 
-        this.signupButton = (Button) findViewById(R.id.signup_button);
-        this.loginButton = (Button) findViewById(R.id.login_button);
-        this.logoutButton = (Button) findViewById(R.id.logout_button);
+        this.signupButton = findViewById(R.id.signup_button);
+        this.loginButton = findViewById(R.id.login_button);
+        this.logoutButton = findViewById(R.id.logout_button);
 
         this.skygear = Container.defaultContainer(this);
     }

--- a/app/src/main/java/io/skygear/skygear_starter_project/MainActivity.java
+++ b/app/src/main/java/io/skygear/skygear_starter_project/MainActivity.java
@@ -9,8 +9,6 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 
-import org.w3c.dom.Text;
-
 import io.skygear.skygear.AuthResponseHandler;
 import io.skygear.skygear.Configuration;
 import io.skygear.skygear.Container;

--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 buildscript {
     repositories {
         jcenter()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.3'
@@ -22,10 +19,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
+        google()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Mar 20 18:50:54 HKT 2017
+#Mon Jul 16 16:18:20 HKT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
- Update Gradle plugin version to 3.1.3 and change deprecated Gradle syntax
- Adapt new Google maven repository endpoint syntax
- Update `targetSdkVersion` and `compileSdkVersion` to 27 (Android 8.1)
- Update `buildTools` version to 27.0.3
- Update Android Support library to 27.1.1
- Add Android Design Support library to better support new Android Support library
- Update Skygear SDK to 1.6.0
- Remove unused import in main activity
- Remove redundant cast in main activity as new version of build tools no longer requires them